### PR TITLE
Фикс писем, к которым приложены письма

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
     - 5.6
-    - hhvm
-    - hhvm-nightly
+    - 7.1
+    - 7.2
+    - 7.3
 
 before_script:
     - composer self-update && composer install --dev
@@ -19,6 +17,3 @@ after_script:
 
 matrix:
     fast_finish: true
-    allow_failures:
-      - php: hhvm
-      - php: hhvm-nightly

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,20 @@
     }
   ],
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.6",
     "ext-imap": "*"
   },
   "require-dev": {
-    "tedivm/dovecottesting": "1.2.3",
+    "tedivm/dovecottesting": "dev-master@dev",
     "phpunit/phpunit": "^5.7",
     "friendsofphp/php-cs-fixer": "^2"
     },
+  "repositories": [
+    {
+      "type": "git",
+      "url": "https://github.com/pm14kas/DovecotTesting"
+    }
+  ],
   "autoload": {
     "psr-0": {"Fetch": "src/"}
   }

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
   },
   "require-dev": {
     "tedivm/dovecottesting": "1.2.3",
-    "phpunit/phpunit": "4.2.*",
-    "fabpot/php-cs-fixer": "0.5.*"
+    "phpunit/phpunit": "^5.7",
+    "friendsofphp/php-cs-fixer": "^2"
     },
   "autoload": {
     "psr-0": {"Fetch": "src/"}

--- a/tests/Fetch/Test/MessageTest.php
+++ b/tests/Fetch/Test/MessageTest.php
@@ -298,4 +298,64 @@ ENCODE;
 
     }
 
+    /**
+     * @dataProvider dataEmailAttachedToEmailProvider
+     * @param $uid
+     * @param $emailBodyPartString
+     * @param $isMultipart
+     */
+    public function testEmailAttachedToEmail($uid, $emailBodyPartString, $isMultipart)
+    {
+        $server = ServerTest::getServer();
+        $this->assertGreaterThanOrEqual($uid, $server->numMessages('UndeliveredTests'));
+        $server->setMailbox('UndeliveredTests');
+
+        $message = new Message($uid, $server);
+
+        $this->assertContains($emailBodyPartString, $message->getMessageBody(true));
+        if ($isMultipart) {
+            $this->assertNotEmpty($message->getAttachments());
+        }
+    }
+
+    public function dataEmailAttachedToEmailProvider()
+    {
+        return [
+            [
+                1,
+                'Sorry, we were unable to deliver your message to the following address.',
+                false,
+            ],
+            [
+                2,
+                'Сообщение не доставлено, так как адрес',
+                true,
+            ],
+            [
+                3,
+                'This is the mail system at host yandex.ru.',
+                true,
+            ],
+            [
+                4,
+                'Это письмо создано автоматически сервером Mail.ru, отвечать на него не нужно.',
+                false,
+            ],
+            [
+                5,
+                'которое Вы отправили, не может быть доставлено одному или',
+                true,
+            ],
+            [
+                6,
+                'Тестирование прикрепленного письма',
+                true,
+            ],
+            [
+                7,
+                'This is the mail system at host yandex.ru.',
+                true,
+            ]
+        ];
+    }
 }


### PR DESCRIPTION
Некоторые письма не загружаются с сервера, так как Fetch неправильно обрабатывает структуру, а imap_fetchstructure иногда плохо определяет тип прикрепленного файла. В этой ветке я поправил загрузку таких писем и добавил тесты через пакет DovecotTesting